### PR TITLE
make shortChannelID optional

### DIFF
--- a/Plasma/Objects/Lightning/ListPeerChannels.swift
+++ b/Plasma/Objects/Lightning/ListPeerChannels.swift
@@ -25,7 +25,7 @@ struct PeerChannel: Codable {
     let ourToSelfDelay, dustLimitMsat, totalMsat: Int
     let closeTo: String
     let inOfferedMsat, outFulfilledMsat: Int
-    let shortChannelID: String
+    let shortChannelID: String?
     let stateChanges: [StateChange]
     let outPaymentsOffered, feeBaseMsat: Int
     //let htlcs: [JSONAny]


### PR DESCRIPTION
Make the short_channel_id optional for decoding a channel.

Untested. Maybe fixes #1?